### PR TITLE
feat: docker-compose.yml modified for deployment

### DIFF
--- a/Docker/Backend/Dockerfile
+++ b/Docker/Backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22.11.0-bookworm
 
-COPY ./tools/ .
+COPY ./Docker/Backend/tools/ .
 RUN chmod +x /setup.sh
 
 WORKDIR /backend

--- a/Docker/Backend/Dockerfile
+++ b/Docker/Backend/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:22.11.0-bookworm
 
+COPY ./Backend /backend
 COPY ./Docker/Backend/tools/ .
 RUN chmod +x /setup.sh
 

--- a/Docker/Backend/Dockerfile
+++ b/Docker/Backend/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:22.11.0-bookworm
 
 COPY ./Backend /backend
-COPY ./Docker/Backend/tools/ .
-RUN chmod +x /setup.sh
+COPY ./Docker/Backend/tools/setup.sh /scripts/setup.sh
+RUN chmod +x /scripts/setup.sh
 
 WORKDIR /backend
 
-ENTRYPOINT [ "bash", "/setup.sh" ]
+CMD [ "/scripts/setup.sh" ]

--- a/Docker/Backend/tools/setup.sh
+++ b/Docker/Backend/tools/setup.sh
@@ -8,4 +8,4 @@ if [ "$BACKEND_NODE_ENV" = "development" ]; then
   echo "Fixtures loaded successfully!"
 fi
 
-npm run dev
+npm run start

--- a/Docker/Frontend/Dockerfile
+++ b/Docker/Frontend/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:22.11.0-bookworm
 
+COPY ./Frontend /Frontend
 COPY ./Docker/Frontend/tools/ .
 RUN chmod +x /setup.sh
 

--- a/Docker/Frontend/Dockerfile
+++ b/Docker/Frontend/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22.11.0-bookworm
 
-COPY ./tools/ .
+COPY ./Docker/Frontend/tools/ .
 RUN chmod +x /setup.sh
 
 WORKDIR /Frontend

--- a/Docker/Frontend/Dockerfile
+++ b/Docker/Frontend/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:22.11.0-bookworm
 
 COPY ./Frontend /Frontend
-COPY ./Docker/Frontend/tools/ .
-RUN chmod +x /setup.sh
+COPY ./Docker/Frontend/tools/setup.sh /scripts/setup.sh
+RUN chmod +x /scripts/setup.sh
 
 WORKDIR /Frontend
 
-ENTRYPOINT [ "bash", "/setup.sh" ]
+CMD [ "/scripts/setup.sh" ]

--- a/Docker/PostgreSQL/Dockerfile
+++ b/Docker/PostgreSQL/Dockerfile
@@ -1,3 +1,3 @@
 FROM bitnami/postgresql:16.4.0
 
-COPY ./init/init.sql /docker-entrypoint-initdb.d
+COPY ./Docker/PostgreSQL/init/init.sql /docker-entrypoint-initdb.d

--- a/Frontend/vite.config.ts
+++ b/Frontend/vite.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
   server: {
     host: "0.0.0.0",
     port: 5173,
+    allowedHosts: ["matcha.flamiing.com"],
   },
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ services:
     postgresql:
         container_name: postgresql
         build:
-            context: ./Docker/PostgreSQL
-            dockerfile: Dockerfile
+            context: .
+            dockerfile: ./Docker/PostgreSQL/Dockerfile
         volumes:
             - postgresql_volume:/var/lib/postgresql
         networks:
@@ -32,8 +32,8 @@ services:
     backend:
         container_name: backend
         build:
-            context: ./Docker/Backend
-            dockerfile: Dockerfile
+            context: .
+            dockerfile: ./Docker/Backend/Dockerfile
         volumes:
             - ./Backend:/backend
             - ./uploads:/uploads
@@ -52,8 +52,8 @@ services:
     frontend:
         container_name: frontend
         build:
-            context: ./Docker/Frontend
-            dockerfile: Dockerfile
+            context: .
+            dockerfile: ./Docker/Frontend/Dockerfile
         volumes:
             - ./Frontend:/Frontend
         networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
             context: .
             dockerfile: ./Docker/Backend/Dockerfile
         volumes:
-            - ./Backend:/backend
             - ./uploads:/uploads
         networks:
             - matcha-network
@@ -54,8 +53,6 @@ services:
         build:
             context: .
             dockerfile: ./Docker/Frontend/Dockerfile
-        volumes:
-            - ./Frontend:/Frontend
         networks:
             - matcha-network
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
             context: .
             dockerfile: ./Docker/Backend/Dockerfile
         volumes:
-            - ./uploads:/uploads
+            - uploads_volume:/uploads
         networks:
             - matcha-network
         environment:
@@ -66,11 +66,8 @@ services:
 
 volumes:
     postgresql_volume:
-        driver: local
-        driver_opts:
-            type: "none"
-            o: "bind"
-            device: "${POSTGRESQL_VOLUME_PATH}"
+    uploads_volume:
+        
 networks:
     matcha-network:
         driver: bridge


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` file to adjust the `context` and `dockerfile` paths for the `postgresql`, `backend`, and `frontend` services. These changes ensure that the build context is set to the project root directory and specify the correct paths for the Dockerfiles within their respective service directories.

### Changes to Docker service configurations:

* `docker-compose.yml` (`postgresql` service): Updated the `context` to the project root directory and the `dockerfile` path to `./Docker/PostgreSQL/Dockerfile`.
* `docker-compose.yml` (`backend` service): Updated the `context` to the project root directory and the `dockerfile` path to `./Docker/Backend/Dockerfile`.
* `docker-compose.yml` (`frontend` service): Updated the `context` to the project root directory and the `dockerfile` path to `./Docker/Frontend/Dockerfile`.